### PR TITLE
Infer exclude_fields when not set

### DIFF
--- a/dj_anonymizer/register_models.py
+++ b/dj_anonymizer/register_models.py
@@ -66,8 +66,7 @@ def register_anonym(models):
         else:
             exclude_fields = {
                 field.name for field in model._meta.get_fields()
-                if isinstance(field, Field) and field.name
-                   not in anonym_fields
+                if isinstance(field, Field) and field.name not in anonym_fields
             }
 
         model_fields = set(

--- a/dj_anonymizer/register_models.py
+++ b/dj_anonymizer/register_models.py
@@ -59,8 +59,16 @@ def register_anonym(models):
     for model, cls_anonym in models:
         cls_anonym.init_meta(model)
 
-        exclude_fields = set(cls_anonym.Meta.exclude_fields)
         anonym_fields = set(cls_anonym.get_fields_names())
+
+        if hasattr(cls_anonym.Meta, 'exclude_fields'):
+            exclude_fields = set(cls_anonym.Meta.exclude_fields)
+        else:
+            exclude_fields = {
+                field.name for field in model._meta.get_fields()
+                if isinstance(field, Field) and field.name
+                   not in anonym_fields
+            }
 
         model_fields = set(
             field.name for field in model._meta.get_fields()

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Unreleased
 ----------
 
 * Feature: possibility to truncate register_clean tables (`#41 <https://github.com/preply/dj_anonymizer/pull/41>`__)
+* Feature: infer exclude_fields when property is not set (`#45 <https://github.com/preply/dj_anonymizer/pull/45>`__)
 
 Breaking:
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -82,7 +82,7 @@ Example::
 
 In `class Meta` you can specify `queryset` and `exclude_fields`:
  * `queryset` - model queryset to which anonymization will be applied. If you don't specify this attribute, anonymization will be applied to all rows of model (like `MyModel.objects.all()`)
- * `exclude_fields` - list of model fields which should not be anonymized
+ * `exclude_fields` - list of model fields which should not be anonymized. If you don't specify this attribute, the excluded fields will be inferred automatically
 
 dj_anonymizer provides certain helpful field types for anonymization classes:
 


### PR DESCRIPTION
Hello sirs, there's a PR for your consideration.

This might be useful for models that have many fields to be excluded. With this change, dj_anonymizer should be able to infer the list of excluded without explicitly setting them. 

Since you don't have contribution guidelines, I've ensured this PR supports 100% backwards compatibility. 

Thanks