### PR TITLE
Handle Windows paths in module import

### DIFF
--- a/dj_anonymizer/utils.py
+++ b/dj_anonymizer/utils.py
@@ -19,9 +19,12 @@ def import_if_exist(filename):
     Check if file exist in appropriate path and import it
     """
     filepath = os.path.join(settings.ANONYMIZER_MODEL_DEFINITION_DIR, filename)
+    full_filepath = os.path.abspath(filepath + '.py')
 
-    if os.path.isfile(os.path.abspath(filepath + '.py')):
-        importlib.import_module(filepath.replace('/', '.'))
+    if os.path.isfile(full_filepath):
+        spec = importlib.util.spec_from_file_location(filename, full_filepath)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
 
 
 def truncate_table(model):


### PR DESCRIPTION
Running this on Windows did not work with the replace of /
This imports the file directly from: https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly

This could allow eventually for the anonymizer file to be located anywhere instead of the specific anonymizer directory. eg. app/anonymizer.py allowing to keep everything together for each app.