### PR TITLE
fix issue when model manager is overridden

### DIFF
--- a/dj_anonymizer/anonymizer.py
+++ b/dj_anonymizer/anonymizer.py
@@ -74,7 +74,7 @@ class Anonymizer:
                         setattr(obj, name, next(
                             getattr(anonym_cls, name))
                         )
-                subset.model.objects.bulk_update(
+                queryset.bulk_update(
                     subset,
                     anonym_cls.get_fields_names(),
                     batch_size=settings.ANONYMIZER_UPDATE_BATCH_SIZE,


### PR DESCRIPTION
In cases like 
```
class Choice(models.Model):
    question = models.ForeignKey(Question, on_delete=models.CASCADE)
    choice_text = models.CharField(max_length=200)
    votes = models.IntegerField(default=0)

    objects = VotesManager()


class VotesManager(models.Manager):
    def get_queryset(self):
        return super().get_queryset().exclude(votes=0)
```

The anonymization process will skip such cases even if queryset in the anonymization class would be overridden.
