### PR TITLE
remove isort warning for -rc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ help: ## Show help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 isort: ## run isort and change imports order
-	isort -rc dj_anonymizer example tests
+	isort dj_anonymizer example tests
 
 isort_check_only: ## run isort and show diff
-	isort -rc -c dj_anonymizer example tests
+	isort -c dj_anonymizer example tests
 
 flake8: ## run flake8
 	flake8 .

--- a/tox.ini
+++ b/tox.ini
@@ -30,5 +30,5 @@ commands = make flake8
 deps = flake8==7.0.0
 
 [testenv:isort]
-commands = make isort
+commands = make isort_check_only
 deps = isort==5.13.2


### PR DESCRIPTION
https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0.html
> Prior to version 5.0.0, isort wouldn't automatically traverse directories. The --recursive option was necessary to tell it to do so. In 5.0.0 directories are automatically traversed for all Python files, and as such this option is no longer necessary and should simply be removed.

